### PR TITLE
[Feature] New HeaderLineClassedRule which allows custom styling for LHeaders

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -1,0 +1,109 @@
+package com.discord.simpleast.sample
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.support.annotation.StyleRes
+import android.text.style.BulletSpan
+import android.text.style.CharacterStyle
+import android.text.style.StyleSpan
+import android.text.style.TextAppearanceSpan
+import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.node.TextNode
+import com.discord.simpleast.core.parser.ParseSpec
+import com.discord.simpleast.core.parser.Parser
+import com.discord.simpleast.core.parser.Rule
+import com.discord.simpleast.core.simple.SimpleMarkdownRules
+import com.discord.simpleast.markdown.MarkdownRules
+import java.util.regex.Matcher
+
+/**
+ * Custom markdown rules to show potential of the framework if you have a bit of creativity.
+ *
+ * @see MarkdownRules.createMarkdownRules for the default setting
+ */
+object CustomMarkdownRules {
+
+  /**
+   * Searches for the pattern:
+   *
+   * `Some header title {capture this string}`
+   */
+  private val PATTERN_HEADING_CLASS = """^(.*) \{([\w ]+)\}\s*$""".toRegex().toPattern()
+
+  fun <R> createMarkdownRules(context: Context,
+                              @StyleRes headerStyles: List<Int>,
+                              @StyleRes classStyles: List<Int>) =
+      createHeaderRules<R>(context, headerStyles, classStyles) + MarkdownRules.ListItemRule {
+        BulletSpan(24, Color.parseColor("#6E7B7F"))
+      }
+
+  private fun <R> createHeaderRules(context: Context,
+                                    @StyleRes headerStyles: List<Int>,
+                                    @StyleRes classStyles: List<Int>): List<Rule<R, Node<R>>> {
+    fun spanProvider(header: Int): CharacterStyle =
+        when (header) {
+          0 -> TextAppearanceSpan(context, headerStyles[0])
+          in 1..headerStyles.size -> TextAppearanceSpan(context, headerStyles[header - 1])
+          else -> StyleSpan(Typeface.BOLD_ITALIC)
+        }
+
+    return listOf(
+        MarkdownRules.HeaderRule(::spanProvider),
+        HeaderLineClassedRule(::spanProvider) {className ->
+          when (className) {
+            "add" -> TextAppearanceSpan(context, classStyles[0])
+            "remove" -> TextAppearanceSpan(context, classStyles[1])
+            "fix" -> TextAppearanceSpan(context, classStyles[2])
+            else -> null
+          }
+        }
+    )
+  }
+
+  /**
+   * Allow lined headers that specify custom styles via markdown.
+   *
+   * @see createClassedSuffixedRule
+   */
+  class HeaderLineClassedRule<R>(styleSpanProvider: (Int) -> CharacterStyle, classSpanProvider: (String) -> CharacterStyle?) :
+      MarkdownRules.HeaderLineRule<R>(styleSpanProvider) {
+
+    private val innerRules = listOf<Rule<R, Node<R>>>(
+        createClassedSuffixedRule(classSpanProvider),
+        SimpleMarkdownRules.createTextRule()
+    )
+
+    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
+      return if (isNested) {
+        ParseSpec.createTerminal(TextNode(matcher.group()))
+      } else {
+        val children = parser.parse(matcher.group(1), true, innerRules)
+        val node: Node<R> = if (children.size == 1) {
+          children.first() as Node<R>
+        } else {
+          createHeaderStyleNode(matcher).apply {
+            for (child in children) {
+              addChild(child as Node<R>)
+            }
+          }
+        }
+
+        ParseSpec.createTerminal(node)
+      }
+    }
+
+    private fun <T> createClassedSuffixedRule(classSpanProvider: (String) -> CharacterStyle?): Rule<T, Node<T>> =
+        object : Rule<T, Node<T>>(PATTERN_HEADING_CLASS, true) {
+          override fun parse(matcher: Matcher, parser: Parser<T, in Node<T>>, isNested: Boolean): ParseSpec<T, Node<T>> {
+            val classes = matcher.group(2).split(' ')
+            val classSpans = classes.mapNotNull(classSpanProvider)
+
+            val node = StyleNode<T>(classSpans)
+            return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+          }
+        }
+
+  }
+}

--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -9,14 +9,8 @@ import android.text.style.CharacterStyle
 import android.text.style.StyleSpan
 import android.text.style.TextAppearanceSpan
 import com.discord.simpleast.core.node.Node
-import com.discord.simpleast.core.node.StyleNode
-import com.discord.simpleast.core.node.TextNode
-import com.discord.simpleast.core.parser.ParseSpec
-import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
-import com.discord.simpleast.core.simple.SimpleMarkdownRules
 import com.discord.simpleast.markdown.MarkdownRules
-import java.util.regex.Matcher
 
 /**
  * Custom markdown rules to show potential of the framework if you have a bit of creativity.
@@ -24,13 +18,6 @@ import java.util.regex.Matcher
  * @see MarkdownRules.createMarkdownRules for the default setting
  */
 object CustomMarkdownRules {
-
-  /**
-   * Searches for the pattern:
-   *
-   * `Some header title {capture this string}`
-   */
-  private val PATTERN_HEADING_CLASS = """^(.*) \{([\w ]+)\}\s*$""".toRegex().toPattern()
 
   fun <R> createMarkdownRules(context: Context,
                               @StyleRes headerStyles: List<Int>,
@@ -51,7 +38,7 @@ object CustomMarkdownRules {
 
     return listOf(
         MarkdownRules.HeaderRule(::spanProvider),
-        HeaderLineClassedRule(::spanProvider) {className ->
+        MarkdownRules.HeaderLineClassedRule(::spanProvider) { className ->
           when (className) {
             "add" -> TextAppearanceSpan(context, classStyles[0])
             "remove" -> TextAppearanceSpan(context, classStyles[1])
@@ -60,50 +47,5 @@ object CustomMarkdownRules {
           }
         }
     )
-  }
-
-  /**
-   * Allow lined headers that specify custom styles via markdown.
-   *
-   * @see createClassedSuffixedRule
-   */
-  class HeaderLineClassedRule<R>(styleSpanProvider: (Int) -> CharacterStyle, classSpanProvider: (String) -> CharacterStyle?) :
-      MarkdownRules.HeaderLineRule<R>(styleSpanProvider) {
-
-    private val innerRules = listOf<Rule<R, Node<R>>>(
-        createClassedSuffixedRule(classSpanProvider),
-        SimpleMarkdownRules.createTextRule()
-    )
-
-    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
-      return if (isNested) {
-        ParseSpec.createTerminal(TextNode(matcher.group()))
-      } else {
-        val children = parser.parse(matcher.group(1), true, innerRules)
-        val node: Node<R> = if (children.size == 1) {
-          children.first() as Node<R>
-        } else {
-          createHeaderStyleNode(matcher).apply {
-            for (child in children) {
-              addChild(child as Node<R>)
-            }
-          }
-        }
-
-        ParseSpec.createTerminal(node)
-      }
-    }
-
-    private fun <T> createClassedSuffixedRule(classSpanProvider: (String) -> CharacterStyle?): Rule<T, Node<T>> =
-        object : Rule<T, Node<T>>(PATTERN_HEADING_CLASS, true) {
-          override fun parse(matcher: Matcher, parser: Parser<T, in Node<T>>, isNested: Boolean): ParseSpec<T, Node<T>> {
-            val classes = matcher.group(2).split(' ')
-            val classSpans = classes.mapNotNull(classSpanProvider)
-
-            val node = StyleNode<T>(classSpans)
-            return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
-          }
-        }
-
   }
 }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -16,20 +16,23 @@ import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.core.simple.SimpleMarkdownRules
 import com.discord.simpleast.core.simple.SimpleRenderer
-import com.discord.simpleast.markdown.MarkdownRules
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 private const val SAMPLE_TEXT = """
   Some really long introduction text that goes on forever explaining something.
 
-  FIRST.Title italics word
+  Alt. __H1__ title
   =======
 
-  Title _italics_ word
+  Alt. __H1__ classed {remove}
+  =======
+
+  Alt. __H2__ title
   -----
   * **bold item**
   * another point that is really obvious but just explained to death and should be half the length in reality
+
 
   # Conclusion __H1__
   So in conclusion. This whole endeavour was just a really long waste of time.
@@ -74,8 +77,12 @@ class MainActivity : AppCompatActivity() {
     findViewById<View>(R.id.test_btn).setOnClickListener {
       val parser = Parser<RenderContext, Node<RenderContext>>()
           .addRule(UserMentionRule())
-          .addRules(MarkdownRules.createMarkdownRules(
-              this, listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3)))
+          .addRules(CustomMarkdownRules.createMarkdownRules(
+              this,
+              listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3),
+              listOf(R.style.Demo_Header_1_Add, R.style.Demo_Header_1_Remove, R.style.Demo_Header_1_Fix)))
+//          .addRules(MarkdownRules.createMarkdownRules(
+//              this, listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3)))
           .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
 
       resultText.text = SimpleRenderer.render(

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,4 +26,17 @@
         <item name="android:textStyle">italic</item>
     </style>
 
+    <style name="Demo.Header.1.Add">
+        <item name="android:textColor">#11c766</item>
+    </style>
+
+    <style name="Demo.Header.1.Remove" >
+        <item name="android:textColor">#e13c54</item>
+    </style>
+
+    <style name="Demo.Header.1.Fix" >
+        <item name="android:textColor">#efc312</item>
+    </style>
+
+
 </resources>

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -26,8 +26,15 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
     return this
   }
 
+  /**
+   * Transforms the [source] to a AST of [Node]s using the provided [rules].
+   *
+   * @param rules Ordered [List] of rules to use to convert the source to nodes.
+   *    If not set, the parser will use its global list of [Parser.rules].
+   */
   @JvmOverloads
-  fun parse(source: CharSequence?, isNested: Boolean = false): MutableList<T> {
+  fun parse(source: CharSequence?, isNested: Boolean = false,
+            rules: List<Rule<R, out T>> = this.rules): MutableList<T> {
     val remainingParses = Stack<ParseSpec<R, out T>>()
     val topLevelNodes = ArrayList<T>()
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -35,9 +35,9 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher,
    * A [Rule] that ensures that the [matcher] is only executed if the preceding capture was a newline.
    * e.g. this ensures that the regex parses from a newline.
    */
-  abstract class BlockRule<R, T : Node<R>>(matcher: Matcher,
+  abstract class BlockRule<R, T : Node<R>>(pattern: Pattern,
                                            applyOnNestedParse: Boolean = false) :
-      Rule<R, T>(matcher, applyOnNestedParse) {
+      Rule<R, T>(pattern, applyOnNestedParse) {
 
     override fun match(inspectionSource: CharSequence, lastCapture: String?): Matcher? {
       if (lastCapture?.endsWith('\n') != false) {

--- a/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
@@ -75,18 +75,23 @@ object MarkdownRules {
     }
   }
 
-  class HeaderLineRule<R>(private val styleSpanProvider: (Int) -> CharacterStyle) :
+  open class HeaderLineRule<R>(private val styleSpanProvider: (Int) -> CharacterStyle) :
       Rule.BlockRule<R, Node<R>>(HEADER_ITEM_ALT.matcher(""), false) {
 
     override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean)
         : ParseSpec<R, Node<R>> {
+      val node = createHeaderStyleNode(matcher)
+      return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+    }
+
+    protected fun createHeaderStyleNode(matcher: Matcher): StyleNode<R> {
       val headerStyleGroup = matcher.group(2)
       val headerIndicator = when (headerStyleGroup) {
         "=" -> 1
         else -> 2
       }
       val node = StyleNode<R>(listOf(styleSpanProvider(headerIndicator)))
-      return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+      return node
     }
   }
 


### PR DESCRIPTION
Add ability to specify custom classes to lined headers via a special annotation.

![image](https://user-images.githubusercontent.com/5618601/41798696-7c208ac8-7623-11e8-8e5b-e7630ed71833.png)

### Changes
- new class `HeaderLineClassedRule`
- update sample app to reference the new rule
- refactored `Parser.parse` to now accept the set of rules to run. If not specified will use the full list of rules the `Parser` knows about.

### TODO
- remove need for `isNested` parameter in `Parser.parse`