### PR TITLE
Allow StyleNode to be more flexiable in the spannables it applies

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -8,9 +8,11 @@ import android.text.style.BulletSpan
 import android.text.style.CharacterStyle
 import android.text.style.StyleSpan
 import android.text.style.TextAppearanceSpan
+import com.agarron.simpleast.R
 import com.discord.simpleast.core.node.Node
 import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.markdown.MarkdownRules
+import com.discord.simpleast.sample.spans.VerticalMarginSpan
 
 /**
  * Custom markdown rules to show potential of the framework if you have a bit of creativity.
@@ -19,16 +21,16 @@ import com.discord.simpleast.markdown.MarkdownRules
  */
 object CustomMarkdownRules {
 
-  fun <R> createMarkdownRules(context: Context,
+  fun <RC> createMarkdownRules(context: Context,
                               @StyleRes headerStyles: List<Int>,
                               @StyleRes classStyles: List<Int>) =
-      createHeaderRules<R>(context, headerStyles, classStyles) + MarkdownRules.ListItemRule {
+      createHeaderRules<RC>(context, headerStyles, classStyles) + MarkdownRules.ListItemRule {
         BulletSpan(24, Color.parseColor("#6E7B7F"))
       }
 
-  private fun <R> createHeaderRules(context: Context,
+  private fun <RC> createHeaderRules(context: Context,
                                     @StyleRes headerStyles: List<Int>,
-                                    @StyleRes classStyles: List<Int>): List<Rule<R, Node<R>>> {
+                                    @StyleRes classStyles: List<Int>): List<Rule<RC, Node<RC>>> {
     fun spanProvider(header: Int): CharacterStyle =
         when (header) {
           0 -> TextAppearanceSpan(context, headerStyles[0])
@@ -36,13 +38,17 @@ object CustomMarkdownRules {
           else -> StyleSpan(Typeface.BOLD_ITALIC)
         }
 
+    val marginTopPx = context.resources.getDimensionPixelSize(R.dimen.markdown_margin_top)
+
     return listOf(
         MarkdownRules.HeaderRule(::spanProvider),
         MarkdownRules.HeaderLineClassedRule(::spanProvider) { className ->
+          @Suppress("IMPLICIT_CAST_TO_ANY")
           when (className) {
             "add" -> TextAppearanceSpan(context, classStyles[0])
             "remove" -> TextAppearanceSpan(context, classStyles[1])
             "fix" -> TextAppearanceSpan(context, classStyles[2])
+            "marginTop" -> VerticalMarginSpan(topPx = marginTopPx, bottomPx = marginTopPx / 2)
             else -> null
           }
         }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -25,7 +25,7 @@ private const val SAMPLE_TEXT = """
   Alt. __H1__ title
   =======
 
-  Alt. __H1__ classed {remove}
+  Alt. __H1__ classed {remove marginTop}
   =======
 
   Alt. __H2__ title

--- a/app/src/main/java/com/discord/simpleast/sample/spans/VerticalMarginSpan.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/spans/VerticalMarginSpan.kt
@@ -1,0 +1,19 @@
+package com.discord.simpleast.sample.spans
+
+import android.graphics.Paint
+import android.support.annotation.Dimension
+import android.text.style.LineHeightSpan
+
+
+/**
+ * Simple [Span] that adds pixels to a span vertically.
+ */
+class VerticalMarginSpan(@Dimension private val topPx: Int,
+                         @Dimension private val bottomPx: Int) : LineHeightSpan {
+
+  override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int,
+                   fm: Paint.FontMetricsInt) {
+    fm.ascent -= topPx
+    fm.descent += bottomPx
+  }
+}

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="markdown_margin_top">24dp</dimen>
+</resources>

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/node/StyleNode.kt
@@ -4,9 +4,14 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.CharacterStyle
 
-open class StyleNode<R>(val styles: List<CharacterStyle>) : Node<R>() {
 
-  override fun render(builder: SpannableStringBuilder, renderContext: R) {
+/**
+ * @param RC RenderContext
+ * @param T Type of Span to apply
+ */
+open class StyleNode<RC, T>(val styles: List<T>) : Node<RC>() {
+
+  override fun render(builder: SpannableStringBuilder, renderContext: RC) {
     val startIndex = builder.length
 
     // First render all child nodes, as these are the nodes we want to apply the styles to.
@@ -27,8 +32,8 @@ open class StyleNode<R>(val styles: List<CharacterStyle>) : Node<R>() {
      * the text content will be.
      */
     @JvmStatic
-    fun <R> createWithText(content: String, styles: List<CharacterStyle>): StyleNode<R> {
-      val styleNode = StyleNode<R>(styles)
+    fun <RC> createWithText(content: String, styles: List<CharacterStyle>): StyleNode<RC, CharacterStyle> {
+      val styleNode = StyleNode<RC, CharacterStyle>(styles)
       styleNode.addChild(TextNode(content))
       return styleNode
     }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -92,7 +92,7 @@ object SimpleMarkdownRules {
         val styles = ArrayList<CharacterStyle>(1)
         styles.add(StyleSpan(Typeface.ITALIC))
 
-        val node = StyleNode<R>(styles)
+        val node = StyleNode<R, CharacterStyle>(styles)
         return ParseSpec.createNonterminal(node, startIndex, endIndex)
       }
     }
@@ -117,7 +117,7 @@ object SimpleMarkdownRules {
   fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(pattern, false) {
       override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
-        val node = StyleNode<R>(styleFactory())
+        val node = StyleNode<R, CharacterStyle>(styleFactory())
         return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
       }
     }


### PR DESCRIPTION
# Breaking change to `StyleNode`
- Required to allow spannables other than `CharacterStyle` types.
- Android allows any object type to be passed in as part of `setSpan` so the node should similarly be as accepting.
- example added to display vertical margin spans

![image](https://user-images.githubusercontent.com/5618601/41878767-65b9f07a-788b-11e8-8872-e01661c5e4ad.png)
