### PR TITLE
[Android] Remove nested paradigm and relay on inner rules

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -127,7 +127,7 @@ ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'
 
   @Suppress("unused")
   class FooRule : Rule<Any?, Node<Any?>>(Pattern.compile("^<Foo>")) {
-    override fun parse(matcher: Matcher, parser: Parser<Any?, in Node<Any?>>, isNested: Boolean): ParseSpec<Any?, Node<Any?>> {
+    override fun parse(matcher: Matcher, parser: Parser<Any?, in Node<Any?>>): ParseSpec<Any?, Node<Any?>> {
       return ParseSpec.createTerminal(TextNode("Bar"))
     }
   }
@@ -140,7 +140,7 @@ ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'
   }
 
   class UserMentionRule : Rule<RenderContext, UserNode>(Pattern.compile("^<(\\d+)>")) {
-    override fun parse(matcher: Matcher, parser: Parser<RenderContext, in UserNode>, isNested: Boolean): ParseSpec<RenderContext, UserNode> {
+    override fun parse(matcher: Matcher, parser: Parser<RenderContext, in UserNode>): ParseSpec<RenderContext, UserNode> {
       return ParseSpec.createTerminal(UserNode(matcher.group(1).toInt()))
     }
   }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -81,8 +81,6 @@ class MainActivity : AppCompatActivity() {
               this,
               listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3),
               listOf(R.style.Demo_Header_1_Add, R.style.Demo_Header_1_Remove, R.style.Demo_Header_1_Fix)))
-//          .addRules(MarkdownRules.createMarkdownRules(
-//              this, listOf(R.style.Demo_Header_1, R.style.Demo_Header_2, R.style.Demo_Header_3)))
           .addRules(SimpleMarkdownRules.createSimpleMarkdownRules())
 
       resultText.text = SimpleRenderer.render(
@@ -93,7 +91,11 @@ class MainActivity : AppCompatActivity() {
     }
   }
 
-  private fun createTestText() = """[0;31mERROR:[0m Signature extraction failed: Traceback (most recent call last):
+  private fun createTestText() = """
+    Test __Inner **nested** rules__ as well as *look ahead* rules
+    ==========
+
+    [0;31mERROR:[0m Signature extraction failed: Traceback (most recent call last):
   File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/youtube.py", line 1011, in _decrypt_signature
     video_id, player_url, s
   File "/usr/local/lib/python3.5/dist-packages/youtube_dl/extractor/youtube.py", line 925, in _extract_signature_function
@@ -114,8 +116,9 @@ class MainActivity : AppCompatActivity() {
     self._parse()
   File "/usr/lib/python3.5/urllib/request.py", line 324, in _parse
     raise ValueError("unknown url type: %r" % self.full_url)
-ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'
- (caused by ValueError("unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'",))"""
+  ValueError: unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'
+   (caused by ValueError("unknown url type: '/yts/jsbin/player-en_US-vflkk7pUE/base.js'",))
+ """
 
   private fun testParse(times: Int) {
     val text = createTestText()

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -33,8 +33,7 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
    *    If not set, the parser will use its global list of [Parser.rules].
    */
   @JvmOverloads
-  fun parse(source: CharSequence?, isNested: Boolean = false,
-            rules: List<Rule<R, out T>> = this.rules): MutableList<T> {
+  fun parse(source: CharSequence?, rules: List<Rule<R, out T>> = this.rules): MutableList<T> {
     val remainingParses = Stack<ParseSpec<R, out T>>()
     val topLevelNodes = ArrayList<T>()
 
@@ -56,17 +55,13 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
 
       var foundRule = false
       for (rule in rules) {
-        if (isNested && !rule.applyOnNestedParse) {
-          continue
-        }
-
         val matcher = rule.match(inspectionSource, lastCapture)
         if (matcher != null) {
           logMatch(rule, inspectionSource)
           val matcherSourceEnd = matcher.end() + offset
           foundRule = true
 
-          val newBuilder = rule.parse(matcher, this, isNested)
+          val newBuilder = rule.parse(matcher, this)
           val parent = builder.root
 
           newBuilder.root?.let {

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -9,12 +9,9 @@ import java.util.regex.Pattern
  *          See [Node.render]
  * @param T The type of nodes that are handled.
  */
-abstract class Rule<R, T : Node<R>>(val matcher: Matcher,
-                                    val applyOnNestedParse: Boolean = false) {
+abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
 
-  @JvmOverloads
-  constructor(pattern: Pattern, applyOnNestedParse: Boolean = false) :
-      this(pattern.matcher(""), applyOnNestedParse)
+  constructor(pattern: Pattern) : this(pattern.matcher(""))
 
   /**
    * Used to determine if the [Rule] applies to the [inspectionSource].
@@ -29,15 +26,13 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher,
     return if (matcher.find()) matcher else null
   }
 
-  abstract fun parse(matcher: Matcher, parser: Parser<R, in T>, isNested: Boolean): ParseSpec<R, T>
+  abstract fun parse(matcher: Matcher, parser: Parser<R, in T>): ParseSpec<R, T>
 
   /**
    * A [Rule] that ensures that the [matcher] is only executed if the preceding capture was a newline.
    * e.g. this ensures that the regex parses from a newline.
    */
-  abstract class BlockRule<R, T : Node<R>>(pattern: Pattern,
-                                           applyOnNestedParse: Boolean = false) :
-      Rule<R, T>(pattern, applyOnNestedParse) {
+  abstract class BlockRule<R, T : Node<R>>(pattern: Pattern) : Rule<R, T>(pattern) {
 
     override fun match(inspectionSource: CharSequence, lastCapture: String?): Matcher? {
       if (lastCapture?.endsWith('\n') != false) {

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -41,17 +41,17 @@ object SimpleMarkdownRules {
   )
 
   fun <R> createBoldRule(): Rule<R, Node<R>> =
-      createSimpleStyleRule(PATTERN_BOLD, { listOf(StyleSpan(Typeface.BOLD)) })
+      createSimpleStyleRule(PATTERN_BOLD) { listOf(StyleSpan(Typeface.BOLD)) }
 
   fun <R> createUnderlineRule(): Rule<R, Node<R>> =
-      createSimpleStyleRule(PATTERN_UNDERLINE, { listOf(UnderlineSpan()) })
+      createSimpleStyleRule(PATTERN_UNDERLINE) { listOf(UnderlineSpan()) }
 
   fun <R> createStrikethruRule(): Rule<R, Node<R>> =
-      createSimpleStyleRule(PATTERN_STRIKETHRU, { listOf(StrikethroughSpan()) })
+      createSimpleStyleRule(PATTERN_STRIKETHRU) { listOf(StrikethroughSpan()) }
 
   fun <R> createTextRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_TEXT, true) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
+    return object : Rule<R, Node<R>>(PATTERN_TEXT) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
         val node = TextNode<R>(matcher.group())
         return ParseSpec.createTerminal(node)
       }
@@ -59,8 +59,8 @@ object SimpleMarkdownRules {
   }
 
   fun <R> createNewlineRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_NEWLINE, true) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
+    return object : Rule<R, Node<R>>(PATTERN_NEWLINE) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
         val node = TextNode<R>("\n")
         return ParseSpec.createTerminal(node)
       }
@@ -68,16 +68,16 @@ object SimpleMarkdownRules {
   }
 
   fun <R> createEscapeRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_ESCAPE, false) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
+    return object : Rule<R, Node<R>>(PATTERN_ESCAPE) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
         return ParseSpec.createTerminal(TextNode(matcher.group(1)))
       }
     }
   }
 
   fun <R> createItalicsRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_ITALICS, false) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
+    return object : Rule<R, Node<R>>(PATTERN_ITALICS) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
         val startIndex: Int
         val endIndex: Int
         val asteriskMatch = matcher.group(2)
@@ -114,13 +114,12 @@ object SimpleMarkdownRules {
   }
 
   @JvmStatic
-  fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(pattern, false) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, isNested: Boolean): ParseSpec<R, Node<R>> {
-        val node = StyleNode<R, CharacterStyle>(styleFactory())
-        return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+  fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>) =
+      object : Rule<R, Node<R>>(pattern) {
+        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
+          val node = StyleNode<R, CharacterStyle>(styleFactory())
+          return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+        }
       }
-    }
-  }
 }
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleRenderer.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleRenderer.kt
@@ -32,12 +32,12 @@ object SimpleRenderer {
       parser.addRule(rule)
     }
 
-    return render(SpannableStringBuilder(), parser.parse(source, false), renderContext)
+    return render(SpannableStringBuilder(), parser.parse(source), renderContext)
   }
 
   @JvmStatic
   fun <R> render(source: CharSequence, parser: Parser<R, Node<R>>, renderContext: R): SpannableStringBuilder {
-    return render(SpannableStringBuilder(), parser.parse(source, false), renderContext)
+    return render(SpannableStringBuilder(), parser.parse(source), renderContext)
   }
 
   @JvmStatic

--- a/simpleast-core/src/test/java/com/discord/simpleast/core/ParserTest.java
+++ b/simpleast-core/src/test/java/com/discord/simpleast/core/ParserTest.java
@@ -4,13 +4,6 @@ import android.graphics.Typeface;
 import android.text.style.CharacterStyle;
 import android.text.style.StyleSpan;
 
-import com.discord.simpleast.core.node.Node;
-import com.discord.simpleast.core.node.StyleNode;
-import com.discord.simpleast.core.node.TextNode;
-import com.discord.simpleast.core.parser.Parser;
-import com.discord.simpleast.core.simple.SimpleMarkdownRules;
-import com.discord.simpleast.core.utils.TreeMatcher;
-
 import junit.framework.Assert;
 
 import org.junit.After;
@@ -20,6 +13,13 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.discord.simpleast.core.node.Node;
+import com.discord.simpleast.core.node.StyleNode;
+import com.discord.simpleast.core.node.TextNode;
+import com.discord.simpleast.core.parser.Parser;
+import com.discord.simpleast.core.simple.SimpleMarkdownRules;
+import com.discord.simpleast.core.utils.TreeMatcher;
 
 public class ParserTest {
 
@@ -85,7 +85,7 @@ public class ParserTest {
 //            "t"
 //        + "______");
 
-        final StyleNode<Object> boldNode = new StyleNode<>(Collections.singletonList((CharacterStyle) new StyleSpan(Typeface.BOLD)));
+        final StyleNode<Object, ?> boldNode = new StyleNode<>(Collections.singletonList((CharacterStyle) new StyleSpan(Typeface.BOLD)));
         boldNode.addChild(new TextNode<>("bold "));
         boldNode.addChild(StyleNode.Companion.createWithText("and italics",
             Collections.singletonList((CharacterStyle) new StyleSpan(Typeface.ITALIC))));

--- a/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
@@ -104,9 +104,9 @@ class MarkdownRulesTest {
       ### Header 3
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }
@@ -126,9 +126,9 @@ class MarkdownRulesTest {
       other content for listing # of items
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }
@@ -143,9 +143,9 @@ class MarkdownRulesTest {
       some content
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }
@@ -171,9 +171,9 @@ class MarkdownRulesTest {
       some content
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }
@@ -192,9 +192,9 @@ class MarkdownRulesTest {
       some content
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }
@@ -229,9 +229,9 @@ class MarkdownRulesTest {
       some content
       """.trimIndent())
 
-    val styledNodes = ArrayList<StyleNode<*>>()
+    val styledNodes = ArrayList<StyleNode<*, *>>()
     ASTUtils.traversePreOrder(ast) {
-      if (it is StyleNode) {
+      if (it is StyleNode<*, *>) {
         styledNodes.add(it)
       }
     }


### PR DESCRIPTION
# Breaking change
Now that `Parser.parse` allows specifying the rules to use during parse step, we should move to relying on that feature for more explicit and precise parsing. This eliminates the uncertainty and domain knowledge that is required to understand all rules and how they work within nested parses.

In terms of performance, I ran the benchmark and got these averages:

| With nested | Without nested |
| -- | -- |
| 916.86 | 918.4 |

As you can see it's negligible