### PR TITLE
Fix: headers should consume newline

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -48,7 +48,7 @@ object CustomMarkdownRules {
             "add" -> TextAppearanceSpan(context, classStyles[0])
             "remove" -> TextAppearanceSpan(context, classStyles[1])
             "fix" -> TextAppearanceSpan(context, classStyles[2])
-            "marginTop" -> VerticalMarginSpan(topPx = marginTopPx, bottomPx = marginTopPx / 2)
+            "marginTop" -> VerticalMarginSpan(topPx = marginTopPx, bottomPx = 0)
             else -> null
           }
         }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -26,8 +26,9 @@ private const val SAMPLE_TEXT = """
 
   Alt. __H1__ title
   =======
+  stuff
 
-  Alt. __H1__ classed {remove marginTop}
+  Alt. __H1__ remove marginTop {remove marginTop}
   =======
 
   Alt. __H2__ title
@@ -37,6 +38,7 @@ private const val SAMPLE_TEXT = """
 
   # Conclusion __H1__
   So in conclusion. This whole endeavour was just a really long waste of time.
+
 
   ## Appendix __H2__
   ### Sources __H3__

--- a/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
@@ -42,7 +42,7 @@ object MarkdownRules {
    * ### Header 3
    * ```
    */
-  val PATTERN_HEADER_ITEM = """^ *(#+)[ \t](.*) *(?=\n|$)""".toPattern()
+  val PATTERN_HEADER_ITEM = """^\s*(#+)[ \t](.*) *(?=\n|$)""".toPattern()
   /**
    * Handles alternate version of headers. Must have 3+ `=` characters.
    * Example:
@@ -54,7 +54,7 @@ object MarkdownRules {
    * ----------
    * ```
    */
-  val PATTERN_HEADER_ITEM_ALT = """^(?: \t)*(.+)\n *(=|-){3,} *(?=\n|$)""".toPattern()
+  val PATTERN_HEADER_ITEM_ALT = """^\s*(.+)\n *(=|-){3,} *(?=\n|$)""".toPattern()
 
   /**
    * Searches for the pattern:
@@ -138,14 +138,10 @@ object MarkdownRules {
       // Allow the classSuffix rule to apply first, then the normal parsers
       val children = parser.parse(matcher.group(1), innerRules)
 
-      @Suppress("UNCHECKED_CAST")
-      val node: Node<R> = if (children.size == 1) {
-        children.first() as Node<R>
-      } else {
-        createHeaderStyleNode(matcher).apply {
-          for (child in children) {
-            addChild(child as Node<R>)
-          }
+      val node = createHeaderStyleNode(matcher).apply {
+        for (child in children) {
+          @Suppress("UNCHECKED_CAST")
+          addChild(child as Node<R>)
         }
       }
       return ParseSpec.createTerminal(node)


### PR DESCRIPTION
Headers should consume all newlines preceding it (however it's not required). Double checked with VS Code's markdown preview to get same behaviour.

Example
```
Title


# header
```
should generate
![image](https://user-images.githubusercontent.com/5618601/42347955-685ce0b6-805c-11e8-8661-9b934d77a1ae.png)

### Bugfix
Found an issue where, if we were using `HeaderLineClassedRule` it wasn't rendering if the header didn't have multiple children. Updated the tests to use `HeaderLineClassedRule` by default. We already had a standard test for this case, but it wasn't caught because we were using the default `HeaderLineRule` and not the classed version. However, given the classed version being a super set I think it's okay to use that for testing purposes. We also use the classed rule in our actual app anyways.
