### PR TITLE
Fix: Line Headers default values were overriding class headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example:
 If you are building with Gradle, simply add the following line to the dependencies section of your build.gradle file:
 
 ```
-implementation 'com.discord:simpleast:1.0.0'
+implementation 'com.discord:simpleast:1.1.1'
 ```
 
 # Basic Usage with SimpleMarkdownRenderer

--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'com.discord'
-version = '1.1.0'
+version = '1.1.1'
 
 def pomConfig = {
     licenses {

--- a/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.support.annotation.StyleRes
-import android.text.SpannableStringBuilder
-import android.text.Spanned
 import android.text.style.BulletSpan
 import android.text.style.CharacterStyle
 import android.text.style.StyleSpan
@@ -16,7 +14,6 @@ import com.discord.simpleast.core.parser.ParseSpec
 import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.core.simple.SimpleMarkdownRules
-import com.discord.simpleast.markdown.MarkdownRules.HeaderLineClassedRule.Companion.createClassedSuffixedRule
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
@@ -57,13 +54,17 @@ object MarkdownRules {
    * ```
    */
   val PATTERN_HEADER_ITEM_ALT = """^\s*(.+)\n *(=|-){3,} *(?=\n|$)""".toPattern()
-
   /**
-   * Searches for the pattern:
-   *
-   * `Some header title {capture this string}`
+   * Similar to [PATTERN_HEADER_ITEM_ALT] but allows specifying a class type annotation for styling
+   * at the end of the line.
+   * Example:
+   * ```
+   * Alternative Header 1 {red large}
+   * ====================
+   * ```
    */
-  private val PATTERN_HEADING_CLASS = """^(.*) \{([\w ]+)\}\s*$""".toRegex().toPattern()
+  val PATTERN_HEADER_ITEM_ALT_CLASSED =
+      """^\s*(?:(?:(.+)(?: +\{([\w ]*)\}))|(.*))[ \t]*\n *([=\-]){3,}[ \t]*(?=\n|$)""".toRegex().toPattern()
 
   class ListItemRule<R>(private val bulletSpanProvider: () -> BulletSpan) :
       Rule.BlockRule<R, Node<R>>(PATTERN_LIST_ITEM) {
@@ -81,27 +82,25 @@ object MarkdownRules {
 
     constructor(styleSpanProvider: (Int) -> CharacterStyle) : this(PATTERN_HEADER_ITEM, styleSpanProvider)
 
-    protected open fun createHeaderStyleNode(matcher: Matcher): StyleNode<R, CharacterStyle> {
-      val firstGroup = matcher.group(1)
-      val numHeaderIndicators = firstGroup.length
+    protected open fun createHeaderStyleNode(headerStyleGroup: String): StyleNode<R, CharacterStyle> {
+      val numHeaderIndicators = headerStyleGroup.length
       return StyleNode(listOf(styleSpanProvider(numHeaderIndicators)))
     }
 
     override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> =
         ParseSpec.createNonterminal(
-            createHeaderStyleNode(matcher),
+            createHeaderStyleNode(matcher.group(1)),
             matcher.start(2), matcher.end(2))
   }
 
-  open class HeaderLineRule<R>(styleSpanProvider: (Int) -> CharacterStyle) :
-      HeaderRule<R>(PATTERN_HEADER_ITEM_ALT, styleSpanProvider) {
+  open class HeaderLineRule<R>(pattern: Pattern = PATTERN_HEADER_ITEM_ALT, styleSpanProvider: (Int) -> CharacterStyle) :
+      HeaderRule<R>(pattern, styleSpanProvider) {
 
     override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>)
         : ParseSpec<R, Node<R>> = ParseSpec.createNonterminal(
-        createHeaderStyleNode(matcher), matcher.start(1), matcher.end(1))
+        createHeaderStyleNode(matcher.group(2)), matcher.start(1), matcher.end(1))
 
-    override fun createHeaderStyleNode(matcher: Matcher): StyleNode<R, CharacterStyle> {
-      val headerStyleGroup = matcher.group(2)
+    override fun createHeaderStyleNode(headerStyleGroup: String): StyleNode<R, CharacterStyle> {
       val headerIndicator = when (headerStyleGroup) {
         "=" -> 1
         else -> 2
@@ -121,77 +120,40 @@ object MarkdownRules {
    * ==========
    * ```
    *
-   * @param R RenderContext
+   * @param RC RenderContext
    * @param T type of span applied for classes
-   * @see createClassedSuffixedRule
+   * @see PATTERN_HEADER_ITEM_ALT_CLASSED
    */
-  open class HeaderLineClassedRule<R, T : Any>(styleSpanProvider: (Int) -> CharacterStyle,
+  open class HeaderLineClassedRule<RC, T : Any>(styleSpanProvider: (Int) -> CharacterStyle,
                                                @Suppress("MemberVisibilityCanBePrivate")
-                                               protected val innerRules: List<Rule<R, Node<R>>>) :
-      MarkdownRules.HeaderLineRule<R>(styleSpanProvider) {
+                                               val classSpanProvider: (String) -> T?,
+                                               @Suppress("MemberVisibilityCanBePrivate")
+                                               protected val innerRules: List<Rule<RC, Node<RC>>>) :
+      MarkdownRules.HeaderLineRule<RC>(PATTERN_HEADER_ITEM_ALT_CLASSED, styleSpanProvider) {
 
     constructor(styleSpanProvider: (Int) -> CharacterStyle, classSpanProvider: (String) -> T?) :
-        this(styleSpanProvider,
-            listOf(createClassedSuffixedRule<R, T>(classSpanProvider))
-                + SimpleMarkdownRules.createSimpleMarkdownRules<R>(false)
+        this(styleSpanProvider, classSpanProvider,
+            SimpleMarkdownRules.createSimpleMarkdownRules<RC>(false)
                 + SimpleMarkdownRules.createTextRule())
 
-    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
-      // Allow the classSuffix rule to apply first, then the normal parsers
-      val children = parser.parse(matcher.group(1), innerRules)
-
-      val defaultStyleNode = createHeaderStyleNode(matcher)
+    override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>>): ParseSpec<RC, Node<RC>> {
+      val defaultStyleNode = createHeaderStyleNode(matcher.group(4))
+      val headerBody = matcher.group(1) ?: matcher.group(3)
+      val children = parser.parse(headerBody, innerRules)
       @Suppress("UNCHECKED_CAST")
-      val node: Node<R> = if (children.size == 1) {
-        val singleNode = children.first() as Node<R>
-        if (singleNode is HeaderClassNode<R, *>) {
-          singleNode.defaultHeaderStyles = defaultStyleNode.styles
-          singleNode
-        } else {
-          defaultStyleNode.apply { addChild(singleNode) }
-        }
+      children.forEach { defaultStyleNode.addChild(it as Node<RC>) }
+
+      val classes = matcher.group(2)?.trim()?.split(' ')
+      val classSpans = classes?.mapNotNull { classSpanProvider(it) } ?: emptyList()
+
+      val headerNode = if (classSpans.isNotEmpty()) {
+        // Apply class stylings last
+        StyleNode<RC, T>(classSpans).apply { addChild(defaultStyleNode) }
       } else {
-        createHeaderStyleNode(matcher).apply {
-          for (child in children) {
-            addChild(child as Node<R>)
-          }
-        }
-      }
-      return ParseSpec.createTerminal(node)
-    }
-      /**
-       * Denotes a part of the header that allows styling overrides using certain class names.
-       * Set [defaultHeaderStyles] to ensure that class styles are applied after the default styles.
-       */
-      class HeaderClassNode<RC, T>(styles: List<T>) : StyleNode<RC, T>(styles) {
-
-        var defaultHeaderStyles: List<Any>? = null
-
-        override fun render(builder: SpannableStringBuilder, renderContext: RC) {
-          val startIndex = builder.length
-
-          // First render all child nodes, as these are the nodes we want to apply the styles to.
-          getChildren()?.forEach { it.render(builder, renderContext) }
-
-          // Apply the default style first
-          defaultHeaderStyles?.forEach { builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) }
-          styles.forEach { builder.setSpan(it, startIndex, builder.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) }
-        }
+        defaultStyleNode
       }
 
-    companion object {
-      @JvmStatic
-      private fun <RC, T : Any> createClassedSuffixedRule(classSpanProvider: (String) -> T?): Rule<RC, Node<RC>> =
-          object : Rule<RC, Node<RC>>(PATTERN_HEADING_CLASS) {
-            override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>>)
-                : ParseSpec<RC, Node<RC>> {
-              val classes = matcher.group(2).split(' ')
-              val classSpans = classes.mapNotNull { classSpanProvider(it) }
-
-              val node = HeaderClassNode<RC, T>(classSpans)
-              return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
-            }
-          }
+      return ParseSpec.createTerminal(headerNode)
     }
   }
 
@@ -207,7 +169,7 @@ object MarkdownRules {
 
     return listOf(
         HeaderRule(::spanProvider),
-        HeaderLineRule(::spanProvider)
+        HeaderLineRule(styleSpanProvider = ::spanProvider)
     )
   }
 

--- a/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
@@ -253,12 +253,13 @@ class MarkdownRulesTest {
       }
     }
 
-    val lheaderNode = styledNodes[0] as MarkdownRules.HeaderLineClassedRule.HeaderClassNode<*, *>
-    Assert.assertEquals("unrecognized class not styled", 1, lheaderNode.defaultHeaderStyles?.size)
-    Assert.assertTrue("default style applied", lheaderNode.defaultHeaderStyles?.firstOrNull() is StyleSpan)
+    val lheaderNode = styledNodes[0] as StyleNode
+    Assert.assertEquals("unrecognized class not styled", 1, lheaderNode.styles.size)
     Assert.assertTrue("classed style applied", lheaderNode.styles.first() is StrikethroughSpan)
+    val defaultHeaderStyleNode = lheaderNode.getChildren()?.firstOrNull() as StyleNode<*, *>
+    Assert.assertTrue("default style applied", defaultHeaderStyleNode.styles.firstOrNull() is StyleSpan)
 
-    val headerChildren = lheaderNode.getChildren()!!.toList()
+    val headerChildren = defaultHeaderStyleNode.getChildren()!!.toList()
     val italicWord = headerChildren[0]
     val remainingWords = headerChildren[1]
 

--- a/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
+++ b/simpleast-core/src/test/java/com/discord/simpleast/markdown/MarkdownRulesTest.kt
@@ -253,14 +253,12 @@ class MarkdownRulesTest {
       }
     }
 
-    val lheaderNode = styledNodes[0]
-    Assert.assertTrue(lheaderNode.styles.first() is StyleSpan)
+    val lheaderNode = styledNodes[0] as MarkdownRules.HeaderLineClassedRule.HeaderClassNode<*, *>
+    Assert.assertEquals("unrecognized class not styled", 1, lheaderNode.defaultHeaderStyles?.size)
+    Assert.assertTrue("default style applied", lheaderNode.defaultHeaderStyles?.firstOrNull() is StyleSpan)
+    Assert.assertTrue("classed style applied", lheaderNode.styles.first() is StrikethroughSpan)
 
-    val lheaderClassNode = lheaderNode.getChildren()?.firstOrNull() as? StyleNode<*, *>
-    Assert.assertEquals("unrecognized class not styled", 1, lheaderClassNode!!.styles.size)
-    Assert.assertTrue(lheaderClassNode.styles.first() is StrikethroughSpan)
-
-    val headerChildren = lheaderClassNode.getChildren()!!.toList()
+    val headerChildren = lheaderNode.getChildren()!!.toList()
     val italicWord = headerChildren[0]
     val remainingWords = headerChildren[1]
 


### PR DESCRIPTION
This change makes it so that default header styles are applied before the classed header styles are applied.

Given this markdown and the default header style being blue text with BOLD:
```
Header {red}
=======
```
Before:
Header would only be BOLD & blue

After:
Header would only be BOLD & red