### PR TITLE
Add method for rules to be notified of a new parse beginning

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -36,6 +36,10 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
    */
   @JvmOverloads
   fun parse(source: CharSequence?, rules: List<Rule<R, out T>> = this.rules): MutableList<T> {
+    for (rule in rules) {
+      rule.onBeginNewParse()
+    }
+
     val remainingParses = Stack<ParseSpec<R, out T>>()
     val topLevelNodes = ArrayList<T>()
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -41,5 +41,10 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
       return null
     }
   }
+
+  /**
+   * Called when a new parse is started. Can be used to reset internal state between parses.
+   */
+  open fun onBeginNewParse() {}
 }
 


### PR DESCRIPTION
This is a cheap way to allow rules to track very basic state during a parse, such as whether they've matched at all so far, and then reset that state between parses.