### PR TITLE
Add state passing mechanism for parse specs

### DIFF
--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -58,8 +58,8 @@ object CustomMarkdownRules {
   }
 
     interface BlockQuoteState<Self: BlockQuoteState<Self>> {
-        var isInQuote: Boolean
-        fun clone(): Self
+        val isInQuote: Boolean
+        fun newBlockQuoteState(isInQuote: Boolean): Self
     }
 
     /**
@@ -84,8 +84,7 @@ object CustomMarkdownRules {
 
                 override fun parse(matcher: Matcher, parser: Parser<RC, in BlockQuoteNode<RC>, S>, state: S): ParseSpec<RC, BlockQuoteNode<RC>, S> {
                     val groupIndex = if (matcher.group(1) != null) { 1 } else { 2 }
-                    val newState = state.clone()
-                    newState.isInQuote = true
+                    val newState = state.newBlockQuoteState(isInQuote = true)
                     return ParseSpec.createNonterminal(BlockQuoteNode(), newState, matcher.start(groupIndex), matcher.end(groupIndex))
                 }
             }

--- a/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/CustomMarkdownRules.kt
@@ -4,15 +4,17 @@ import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
 import android.support.annotation.StyleRes
-import android.text.style.BulletSpan
-import android.text.style.CharacterStyle
-import android.text.style.StyleSpan
-import android.text.style.TextAppearanceSpan
+import android.text.style.*
 import com.agarron.simpleast.R
 import com.discord.simpleast.core.node.Node
+import com.discord.simpleast.core.node.StyleNode
+import com.discord.simpleast.core.parser.ParseSpec
+import com.discord.simpleast.core.parser.Parser
 import com.discord.simpleast.core.parser.Rule
 import com.discord.simpleast.markdown.MarkdownRules
 import com.discord.simpleast.sample.spans.VerticalMarginSpan
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 /**
  * Custom markdown rules to show potential of the framework if you have a bit of creativity.
@@ -21,16 +23,16 @@ import com.discord.simpleast.sample.spans.VerticalMarginSpan
  */
 object CustomMarkdownRules {
 
-  fun <RC> createMarkdownRules(context: Context,
+  fun <RC, S> createMarkdownRules(context: Context,
                               @StyleRes headerStyles: List<Int>,
                               @StyleRes classStyles: List<Int>) =
-      createHeaderRules<RC>(context, headerStyles, classStyles) + MarkdownRules.ListItemRule {
+      createHeaderRules<RC, S>(context, headerStyles, classStyles) + MarkdownRules.ListItemRule {
         BulletSpan(24, Color.parseColor("#6E7B7F"))
       }
 
-  private fun <RC> createHeaderRules(context: Context,
+  private fun <RC, S> createHeaderRules(context: Context,
                                     @StyleRes headerStyles: List<Int>,
-                                    @StyleRes classStyles: List<Int>): List<Rule<RC, Node<RC>>> {
+                                    @StyleRes classStyles: List<Int>): List<Rule<RC, Node<RC>, S>> {
     fun spanProvider(header: Int): CharacterStyle =
         when (header) {
           0 -> TextAppearanceSpan(context, headerStyles[0])
@@ -54,4 +56,37 @@ object CustomMarkdownRules {
         }
     )
   }
+
+    interface BlockQuoteState<Self: BlockQuoteState<Self>> {
+        var isInQuote: Boolean
+        fun clone(): Self
+    }
+
+    /**
+     * Examples:
+     * > Quoted text
+     *
+     * >>> Quoted text
+     * that is on
+     * multiple lines
+     */
+    private val PATTERN_BLOCK_QUOTE = Pattern.compile("^(?: *>>> ?(.+)| *>(?!>>) ?([^\\n]+\\n?))", Pattern.DOTALL)
+
+    class BlockQuoteNode<RC> : StyleNode<RC, BackgroundColorSpan>(listOf(BackgroundColorSpan(Color.GRAY)))
+
+    // Use a block rule to ensure we only match at the beginning of a line.
+    fun <RC, S: BlockQuoteState<S>> createBlockQuoteRule(): Rule.BlockRule<RC, BlockQuoteNode<RC>, S> =
+            object : Rule.BlockRule<RC, BlockQuoteNode<RC>, S>(PATTERN_BLOCK_QUOTE) {
+                override fun match(inspectionSource: CharSequence, lastCapture: String?, state: S): Matcher? {
+                    // Only do this if we aren't already in a quote.
+                    return if (state.isInQuote) { null } else { super.match(inspectionSource, lastCapture, state) }
+                }
+
+                override fun parse(matcher: Matcher, parser: Parser<RC, in BlockQuoteNode<RC>, S>, state: S): ParseSpec<RC, BlockQuoteNode<RC>, S> {
+                    val groupIndex = if (matcher.group(1) != null) { 1 } else { 2 }
+                    val newState = state.clone()
+                    newState.isInQuote = true
+                    return ParseSpec.createNonterminal(BlockQuoteNode(), newState, matcher.start(groupIndex), matcher.end(groupIndex))
+                }
+            }
 }

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -93,8 +93,8 @@ class MainActivity : AppCompatActivity() {
     parseInput()
   }
 
-  data class ParseState(override var isInQuote: Boolean) : CustomMarkdownRules.BlockQuoteState<ParseState> {
-    override fun clone(): ParseState = ParseState(isInQuote)
+  data class ParseState(override val isInQuote: Boolean) : CustomMarkdownRules.BlockQuoteState<ParseState> {
+    override fun newBlockQuoteState(isInQuote: Boolean): ParseState = ParseState(isInQuote)
   }
 
   private fun parseInput() {

--- a/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
+++ b/app/src/main/java/com/discord/simpleast/sample/MainActivity.kt
@@ -138,8 +138,8 @@ class MainActivity : AppCompatActivity() {
 
   @Suppress("unused")
   class FooRule : Rule<Any?, Node<Any?>>(Pattern.compile("^<Foo>")) {
-    override fun parse(matcher: Matcher, parser: Parser<Any?, in Node<Any?>>): ParseSpec<Any?, Node<Any?>> {
-      return ParseSpec.createTerminal(TextNode("Bar"))
+    override fun parse(matcher: Matcher, parser: Parser<Any?, in Node<Any?>>, state: Map<String, Any>): ParseSpec<Any?, Node<Any?>> {
+      return ParseSpec.createTerminal(TextNode("Bar"), state)
     }
   }
 
@@ -151,8 +151,8 @@ class MainActivity : AppCompatActivity() {
   }
 
   class UserMentionRule : Rule<RenderContext, UserNode>(Pattern.compile("^<(\\d+)>")) {
-    override fun parse(matcher: Matcher, parser: Parser<RenderContext, in UserNode>): ParseSpec<RenderContext, UserNode> {
-      return ParseSpec.createTerminal(UserNode(matcher.group(1).toInt()))
+    override fun parse(matcher: Matcher, parser: Parser<RenderContext, in UserNode>, state: Map<String, Any>): ParseSpec<RenderContext, UserNode> {
+      return ParseSpec.createTerminal(UserNode(matcher.group(1).toInt()), state)
     }
   }
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
@@ -17,18 +17,21 @@ import com.discord.simpleast.core.node.Node
 class ParseSpec<R, T : Node<R>> {
   val root: T?
   val isTerminal: Boolean
+  val state: Map<String, Any>
   var startIndex: Int = 0
   var endIndex: Int = 0
 
-  constructor(root: T?, startIndex: Int, endIndex: Int) {
+  constructor(root: T?, state: Map<String, Any>, startIndex: Int, endIndex: Int) {
     this.root = root
+    this.state = state
     this.isTerminal = false
     this.startIndex = startIndex
     this.endIndex = endIndex
   }
 
-  constructor(root: T?) {
+  constructor(root: T?, state: Map<String, Any>) {
     this.root = root
+    this.state = state
     this.isTerminal = true
   }
 
@@ -40,13 +43,13 @@ class ParseSpec<R, T : Node<R>> {
   companion object {
 
     @JvmStatic
-    fun <R, T : Node<R>> createNonterminal(node: T?, startIndex: Int, endIndex: Int): ParseSpec<R, T> {
-      return ParseSpec(node, startIndex, endIndex)
+    fun <R, T : Node<R>> createNonterminal(node: T?, state: Map<String, Any>, startIndex: Int, endIndex: Int): ParseSpec<R, T> {
+      return ParseSpec(node, state, startIndex, endIndex)
     }
 
     @JvmStatic
-    fun <R, T : Node<R>> createTerminal(node: T?): ParseSpec<R, T> {
-      return ParseSpec(node)
+    fun <R, T : Node<R>> createTerminal(node: T?, state: Map<String, Any>): ParseSpec<R, T> {
+      return ParseSpec(node, state)
     }
   }
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
@@ -14,14 +14,14 @@ import com.discord.simpleast.core.node.Node
  * For terminal subtrees, the root will simply be added to the tree and no additional parsing will
  * take place on the text.
  */
-class ParseSpec<R, T : Node<R>> {
+class ParseSpec<R, T : Node<R>, S> {
   val root: T?
   val isTerminal: Boolean
-  val state: Map<String, Any>
+  val state: S
   var startIndex: Int = 0
   var endIndex: Int = 0
 
-  constructor(root: T?, state: Map<String, Any>, startIndex: Int, endIndex: Int) {
+  constructor(root: T?, state: S, startIndex: Int, endIndex: Int) {
     this.root = root
     this.state = state
     this.isTerminal = false
@@ -29,7 +29,7 @@ class ParseSpec<R, T : Node<R>> {
     this.endIndex = endIndex
   }
 
-  constructor(root: T?, state: Map<String, Any>) {
+  constructor(root: T?, state: S) {
     this.root = root
     this.state = state
     this.isTerminal = true
@@ -43,12 +43,12 @@ class ParseSpec<R, T : Node<R>> {
   companion object {
 
     @JvmStatic
-    fun <R, T : Node<R>> createNonterminal(node: T?, state: Map<String, Any>, startIndex: Int, endIndex: Int): ParseSpec<R, T> {
+    fun <R, T : Node<R>, S> createNonterminal(node: T?, state: S, startIndex: Int, endIndex: Int): ParseSpec<R, T, S> {
       return ParseSpec(node, state, startIndex, endIndex)
     }
 
     @JvmStatic
-    fun <R, T : Node<R>> createTerminal(node: T?, state: Map<String, Any>): ParseSpec<R, T> {
+    fun <R, T : Node<R>, S> createTerminal(node: T?, state: S): ParseSpec<R, T, S> {
       return ParseSpec(node, state)
     }
   }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/ParseSpec.kt
@@ -13,6 +13,11 @@ import com.discord.simpleast.core.node.Node
  *
  * For terminal subtrees, the root will simply be added to the tree and no additional parsing will
  * take place on the text.
+ *
+ * @param R The type of render context needed by the node that this contains.
+ * @param T The type of node that this contains.
+ * @param S The type of state that child nodes will use. This is mainly used to just pass through
+ *          the state back to the parser.
  */
 class ParseSpec<R, T : Node<R>, S> {
   val root: T?

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -10,16 +10,16 @@ import java.util.*
  *          See [Node.render]
  * @param T The type of nodes that are handled.
  */
-open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDebugging: Boolean = false) {
+open class Parser<R, T : Node<R>, S> @JvmOverloads constructor(private val enableDebugging: Boolean = false) {
 
-  private val rules = ArrayList<Rule<R, out T>>()
+  private val rules = ArrayList<Rule<R, out T, S>>()
 
-  fun <C : T> addRule(rule: Rule<R, C>): Parser<R, T> {
+  fun <C : T> addRule(rule: Rule<R, C, S>): Parser<R, T, S> {
     rules.add(rule)
     return this
   }
 
-  fun <C: T> addRules(rules: Collection<Rule<R, C>>): Parser<R, T> {
+  fun <C: T> addRules(rules: Collection<Rule<R, C, S>>): Parser<R, T, S> {
     for (rule in rules) {
       addRule(rule)
     }
@@ -35,14 +35,14 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
    * @throws ParseException for certain specific error flows.
    */
   @JvmOverloads
-  fun parse(source: CharSequence?, rules: List<Rule<R, out T>> = this.rules): MutableList<T> {
-    val remainingParses = Stack<ParseSpec<R, out T>>()
+  fun parse(source: CharSequence?, initialState: S, rules: List<Rule<R, out T, S>> = this.rules): MutableList<T> {
+    val remainingParses = Stack<ParseSpec<R, out T, S>>()
     val topLevelNodes = ArrayList<T>()
 
     var lastCapture: String? = null
 
     if (source != null && !source.isEmpty()) {
-      remainingParses.add(ParseSpec(null, mapOf(), 0, source.length))
+      remainingParses.add(ParseSpec(null, initialState, 0, source.length))
     }
 
     while (!remainingParses.isEmpty()) {
@@ -105,13 +105,13 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
     return topLevelNodes
   }
 
-  private fun <R, T: Node<R>> logMatch(rule: Rule<R, T>, source: CharSequence) {
+  private fun <R, T: Node<R>, S> logMatch(rule: Rule<R, T, S>, source: CharSequence) {
     if (enableDebugging) {
       Log.i(TAG, "MATCH: with rule with pattern: " + rule.matcher.pattern().toString() + " to source: " + source)
     }
   }
 
-  private fun <R, T: Node<R>> logMiss(rule: Rule<R, T>, source: CharSequence) {
+  private fun <R, T: Node<R>, S> logMiss(rule: Rule<R, T, S>, source: CharSequence) {
     if (enableDebugging) {
       Log.i(TAG, "MISS: with rule with pattern: " + rule.matcher.pattern().toString() + " to source: " + source)
     }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Parser.kt
@@ -42,7 +42,7 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
     var lastCapture: String? = null
 
     if (source != null && !source.isEmpty()) {
-      remainingParses.add(ParseSpec(null, 0, source.length))
+      remainingParses.add(ParseSpec(null, mapOf(), 0, source.length))
     }
 
     while (!remainingParses.isEmpty()) {
@@ -57,13 +57,13 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
 
       var foundRule = false
       for (rule in rules) {
-        val matcher = rule.match(inspectionSource, lastCapture)
+        val matcher = rule.match(inspectionSource, lastCapture, builder.state)
         if (matcher != null) {
           logMatch(rule, inspectionSource)
           val matcherSourceEnd = matcher.end() + offset
           foundRule = true
 
-          val newBuilder = rule.parse(matcher, this)
+          val newBuilder = rule.parse(matcher, this, builder.state)
           val parent = builder.root
 
           newBuilder.root?.let {
@@ -73,7 +73,7 @@ open class Parser<R, T : Node<R>> @JvmOverloads constructor(private val enableDe
           // In case the last match didn't consume the rest of the source for this subtree,
           // make sure the rest of the source is consumed.
           if (matcherSourceEnd != builder.endIndex) {
-            remainingParses.push(ParseSpec.createNonterminal(parent, matcherSourceEnd, builder.endIndex))
+            remainingParses.push(ParseSpec.createNonterminal(parent, builder.state, matcherSourceEnd, builder.endIndex))
           }
 
           // We want to speak in terms of indices within the source string,

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -8,6 +8,13 @@ import java.util.regex.Pattern
  * @param R The render context, can be any object that holds what's required for rendering.
  *          See [Node.render]
  * @param T The type of nodes that are handled.
+ * @param S The type of state that this rule needs to match and parse correctly. If the rule
+ *          doesn't need state, this is typically an unbounded generic that's just passed through
+ *          to the [ParseSpec]. If the rule *does* need state, this typically has a bound
+ *          indicating at least one of the interfaces that the concrete state class implements.
+ *          Note that states should **not** be mutated (since that would affect all subsequent
+ *          nodes, not just child nodes), and therefore will likely need some sort of clone method
+ *          in order to create a copy with different values to pass into the returned [ParseSpec].
  */
 abstract class Rule<R, T : Node<R>, S>(val matcher: Matcher) {
 

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -9,7 +9,7 @@ import java.util.regex.Pattern
  *          See [Node.render]
  * @param T The type of nodes that are handled.
  */
-abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
+abstract class Rule<R, T : Node<R>, S>(val matcher: Matcher) {
 
   constructor(pattern: Pattern) : this(pattern.matcher(""))
 
@@ -21,20 +21,20 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
    *
    * @return a [Matcher] if the rule applies, else null
    */
-  open fun match(inspectionSource: CharSequence, lastCapture: String?, state: Map<String, Any>): Matcher? {
+  open fun match(inspectionSource: CharSequence, lastCapture: String?, state: S): Matcher? {
     matcher.reset(inspectionSource)
     return if (matcher.find()) matcher else null
   }
 
-  abstract fun parse(matcher: Matcher, parser: Parser<R, in T>, state: Map<String, Any>): ParseSpec<R, T>
+  abstract fun parse(matcher: Matcher, parser: Parser<R, in T, S>, state: S): ParseSpec<R, T, S>
 
   /**
    * A [Rule] that ensures that the [matcher] is only executed if the preceding capture was a newline.
    * e.g. this ensures that the regex parses from a newline.
    */
-  abstract class BlockRule<R, T : Node<R>>(pattern: Pattern) : Rule<R, T>(pattern) {
+  abstract class BlockRule<R, T : Node<R>, S>(pattern: Pattern) : Rule<R, T, S>(pattern) {
 
-    override fun match(inspectionSource: CharSequence, lastCapture: String?, state: Map<String, Any>): Matcher? {
+    override fun match(inspectionSource: CharSequence, lastCapture: String?, state: S): Matcher? {
       if (lastCapture?.endsWith('\n') != false) {
         return super.match(inspectionSource, lastCapture, state)
       }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/parser/Rule.kt
@@ -21,12 +21,12 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
    *
    * @return a [Matcher] if the rule applies, else null
    */
-  open fun match(inspectionSource: CharSequence, lastCapture: String?): Matcher? {
+  open fun match(inspectionSource: CharSequence, lastCapture: String?, state: Map<String, Any>): Matcher? {
     matcher.reset(inspectionSource)
     return if (matcher.find()) matcher else null
   }
 
-  abstract fun parse(matcher: Matcher, parser: Parser<R, in T>): ParseSpec<R, T>
+  abstract fun parse(matcher: Matcher, parser: Parser<R, in T>, state: Map<String, Any>): ParseSpec<R, T>
 
   /**
    * A [Rule] that ensures that the [matcher] is only executed if the preceding capture was a newline.
@@ -34,9 +34,9 @@ abstract class Rule<R, T : Node<R>>(val matcher: Matcher) {
    */
   abstract class BlockRule<R, T : Node<R>>(pattern: Pattern) : Rule<R, T>(pattern) {
 
-    override fun match(inspectionSource: CharSequence, lastCapture: String?): Matcher? {
+    override fun match(inspectionSource: CharSequence, lastCapture: String?, state: Map<String, Any>): Matcher? {
       if (lastCapture?.endsWith('\n') != false) {
-        return super.match(inspectionSource, lastCapture)
+        return super.match(inspectionSource, lastCapture, state)
       }
       return null
     }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -40,43 +40,43 @@ object SimpleMarkdownRules {
           ")\\*(?!\\*)"
   )
 
-  fun <R> createBoldRule(): Rule<R, Node<R>> =
+  fun <R, S> createBoldRule(): Rule<R, Node<R>, S> =
       createSimpleStyleRule(PATTERN_BOLD) { listOf(StyleSpan(Typeface.BOLD)) }
 
-  fun <R> createUnderlineRule(): Rule<R, Node<R>> =
+  fun <R, S> createUnderlineRule(): Rule<R, Node<R>, S> =
       createSimpleStyleRule(PATTERN_UNDERLINE) { listOf(UnderlineSpan()) }
 
-  fun <R> createStrikethruRule(): Rule<R, Node<R>> =
+  fun <R, S> createStrikethruRule(): Rule<R, Node<R>, S> =
       createSimpleStyleRule(PATTERN_STRIKETHRU) { listOf(StrikethroughSpan()) }
 
-  fun <R> createTextRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_TEXT) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+  fun <R, S> createTextRule(): Rule<R, Node<R>, S> {
+    return object : Rule<R, Node<R>, S>(PATTERN_TEXT) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, Node<R>, S> {
         val node = TextNode<R>(matcher.group())
         return ParseSpec.createTerminal(node, state)
       }
     }
   }
-  fun <R> createNewlineRule(): Rule<R, Node<R>> {
-    return object : Rule.BlockRule<R, Node<R>>(PATTERN_NEWLINE) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+  fun <R, S> createNewlineRule(): Rule<R, Node<R>, S> {
+    return object : Rule.BlockRule<R, Node<R>, S>(PATTERN_NEWLINE) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, Node<R>, S> {
         val node = TextNode<R>("\n")
         return ParseSpec.createTerminal(node, state)
       }
     }
   }
 
-  fun <R> createEscapeRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_ESCAPE) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+  fun <R, S> createEscapeRule(): Rule<R, Node<R>, S> {
+    return object : Rule<R, Node<R>, S>(PATTERN_ESCAPE) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, Node<R>, S> {
         return ParseSpec.createTerminal(TextNode(matcher.group(1)), state)
       }
     }
   }
 
-  fun <R> createItalicsRule(): Rule<R, Node<R>> {
-    return object : Rule<R, Node<R>>(PATTERN_ITALICS) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+  fun <R, S> createItalicsRule(): Rule<R, Node<R>, S> {
+    return object : Rule<R, Node<R>, S>(PATTERN_ITALICS) {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, Node<R>, S> {
         val startIndex: Int
         val endIndex: Int
         val asteriskMatch = matcher.group(2)
@@ -98,8 +98,8 @@ object SimpleMarkdownRules {
   }
 
   @JvmOverloads @JvmStatic
-  fun <R> createSimpleMarkdownRules(includeTextRule: Boolean = true): MutableList<Rule<R, Node<R>>> {
-    val rules = ArrayList<Rule<R, Node<R>>>()
+  fun <R, S> createSimpleMarkdownRules(includeTextRule: Boolean = true): MutableList<Rule<R, Node<R>, S>> {
+    val rules = ArrayList<Rule<R, Node<R>, S>>()
     rules.add(createEscapeRule())
     rules.add(createNewlineRule())
     rules.add(createBoldRule())
@@ -113,9 +113,9 @@ object SimpleMarkdownRules {
   }
 
   @JvmStatic
-  fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>) =
-      object : Rule<R, Node<R>>(pattern) {
-        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+  fun <R, S> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>) =
+      object : Rule<R, Node<R>, S>(pattern) {
+        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>, S>, state: S): ParseSpec<R, Node<R>, S> {
           val node = StyleNode<R, CharacterStyle>(styleFactory())
           return ParseSpec.createNonterminal(node, state, matcher.start(1), matcher.end(1))
         }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleMarkdownRules.kt
@@ -51,32 +51,32 @@ object SimpleMarkdownRules {
 
   fun <R> createTextRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_TEXT) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
         val node = TextNode<R>(matcher.group())
-        return ParseSpec.createTerminal(node)
+        return ParseSpec.createTerminal(node, state)
       }
     }
   }
   fun <R> createNewlineRule(): Rule<R, Node<R>> {
     return object : Rule.BlockRule<R, Node<R>>(PATTERN_NEWLINE) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
         val node = TextNode<R>("\n")
-        return ParseSpec.createTerminal(node)
+        return ParseSpec.createTerminal(node, state)
       }
     }
   }
 
   fun <R> createEscapeRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ESCAPE) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
-        return ParseSpec.createTerminal(TextNode(matcher.group(1)))
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
+        return ParseSpec.createTerminal(TextNode(matcher.group(1)), state)
       }
     }
   }
 
   fun <R> createItalicsRule(): Rule<R, Node<R>> {
     return object : Rule<R, Node<R>>(PATTERN_ITALICS) {
-      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
+      override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
         val startIndex: Int
         val endIndex: Int
         val asteriskMatch = matcher.group(2)
@@ -92,7 +92,7 @@ object SimpleMarkdownRules {
         styles.add(StyleSpan(Typeface.ITALIC))
 
         val node = StyleNode<R, CharacterStyle>(styles)
-        return ParseSpec.createNonterminal(node, startIndex, endIndex)
+        return ParseSpec.createNonterminal(node, state, startIndex, endIndex)
       }
     }
   }
@@ -115,9 +115,9 @@ object SimpleMarkdownRules {
   @JvmStatic
   fun <R> createSimpleStyleRule(pattern: Pattern, styleFactory: () -> List<CharacterStyle>) =
       object : Rule<R, Node<R>>(pattern) {
-        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> {
+        override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> {
           val node = StyleNode<R, CharacterStyle>(styleFactory())
-          return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+          return ParseSpec.createNonterminal(node, state, matcher.start(1), matcher.end(1))
         }
       }
 }

--- a/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleRenderer.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/core/simple/SimpleRenderer.kt
@@ -22,22 +22,22 @@ object SimpleRenderer {
 
   @JvmStatic
   fun renderBasicMarkdown(source: CharSequence): SpannableStringBuilder {
-    return render(source, SimpleMarkdownRules.createSimpleMarkdownRules(), null)
+    return render(source, SimpleMarkdownRules.createSimpleMarkdownRules(), null, null)
   }
 
   @JvmStatic
-  fun <R> render(source: CharSequence, rules: Collection<Rule<R, Node<R>>>, renderContext: R): SpannableStringBuilder {
-    val parser = Parser<R, Node<R>>()
+  fun <R, S> render(source: CharSequence, rules: Collection<Rule<R, Node<R>, S>>, initialState: S, renderContext: R): SpannableStringBuilder {
+    val parser = Parser<R, Node<R>, S>()
     for (rule in rules) {
       parser.addRule(rule)
     }
 
-    return render(SpannableStringBuilder(), parser.parse(source), renderContext)
+    return render(SpannableStringBuilder(), parser.parse(source, initialState), renderContext)
   }
 
   @JvmStatic
-  fun <R> render(source: CharSequence, parser: Parser<R, Node<R>>, renderContext: R): SpannableStringBuilder {
-    return render(SpannableStringBuilder(), parser.parse(source), renderContext)
+  fun <R, S> render(source: CharSequence, parser: Parser<R, Node<R>, S>, renderContext: R, initialState: S): SpannableStringBuilder {
+    return render(SpannableStringBuilder(), parser.parse(source, initialState), renderContext)
   }
 
   @JvmStatic

--- a/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/markdown/MarkdownRules.kt
@@ -69,10 +69,10 @@ object MarkdownRules {
   class ListItemRule<R>(private val bulletSpanProvider: () -> BulletSpan) :
       Rule.BlockRule<R, Node<R>>(PATTERN_LIST_ITEM) {
 
-    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>)
+    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>)
         : ParseSpec<R, Node<R>> {
       val node = MarkdownListItemNode<R>(bulletSpanProvider)
-      return ParseSpec.createNonterminal(node, matcher.start(1), matcher.end(1))
+      return ParseSpec.createNonterminal(node, state, matcher.start(1), matcher.end(1))
     }
   }
 
@@ -87,18 +87,18 @@ object MarkdownRules {
       return StyleNode(listOf(styleSpanProvider(numHeaderIndicators)))
     }
 
-    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>): ParseSpec<R, Node<R>> =
+    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>): ParseSpec<R, Node<R>> =
         ParseSpec.createNonterminal(
-            createHeaderStyleNode(matcher.group(1)),
-            matcher.start(2), matcher.end(2))
+                createHeaderStyleNode(matcher.group(1)),
+                state, matcher.start(2), matcher.end(2))
   }
 
   open class HeaderLineRule<R>(pattern: Pattern = PATTERN_HEADER_ITEM_ALT, styleSpanProvider: (Int) -> CharacterStyle) :
       HeaderRule<R>(pattern, styleSpanProvider) {
 
-    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>)
+    override fun parse(matcher: Matcher, parser: Parser<R, in Node<R>>, state: Map<String, Any>)
         : ParseSpec<R, Node<R>> = ParseSpec.createNonterminal(
-        createHeaderStyleNode(matcher.group(2)), matcher.start(1), matcher.end(1))
+            createHeaderStyleNode(matcher.group(2)), state, matcher.start(1), matcher.end(1))
 
     override fun createHeaderStyleNode(headerStyleGroup: String): StyleNode<R, CharacterStyle> {
       val headerIndicator = when (headerStyleGroup) {
@@ -136,7 +136,7 @@ object MarkdownRules {
             SimpleMarkdownRules.createSimpleMarkdownRules<RC>(false)
                 + SimpleMarkdownRules.createTextRule())
 
-    override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>>): ParseSpec<RC, Node<RC>> {
+    override fun parse(matcher: Matcher, parser: Parser<RC, in Node<RC>>, state: Map<String, Any>): ParseSpec<RC, Node<RC>> {
       val defaultStyleNode = createHeaderStyleNode(matcher.group(4))
       val headerBody = matcher.group(1) ?: matcher.group(3)
       val children = parser.parse(headerBody, innerRules)
@@ -153,7 +153,7 @@ object MarkdownRules {
         defaultStyleNode
       }
 
-      return ParseSpec.createTerminal(headerNode)
+      return ParseSpec.createTerminal(headerNode, state)
     }
   }
 


### PR DESCRIPTION
This allows setting of arbitrary state for child rules. In most cases rules can just pass on the state unchanged, but some rules, such as block quotes, will need the ability to not re-parse quotes inside of a quote, which can be achieved with this state. In these cases, the rule's `parse` method can create a modified copy of the state object to put on the returned `ParseSpec`. We therefore only end up creating new objects when the state actually changes.