### PR TITLE
Bump version to 2.0

### DIFF
--- a/simpleast-core/build.gradle
+++ b/simpleast-core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'com.discord'
-version = '1.1.4'
+version = '2.0.0'
 
 def pomConfig = {
     licenses {


### PR DESCRIPTION
The previous change introduced breaking changes in the API, so let's bump the major version number.