### PR TITLE
Add additional languages alternatives to be consistent with desktop client

### DIFF
--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -253,7 +253,7 @@ object CodeRules {
         "ts" to typescriptRules,
         "typescript" to typescriptRules,
 
-        "patch" to diffRules
+        "patch" to diffRules,
         "diff" to diffRules
     )
   }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -253,6 +253,7 @@ object CodeRules {
         "ts" to typescriptRules,
         "typescript" to typescriptRules,
 
+        "patch" to diffRules
         "diff" to diffRules
     )
   }

--- a/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
+++ b/simpleast-core/src/main/java/com/discord/simpleast/code/CodeRules.kt
@@ -234,6 +234,7 @@ object CodeRules {
 
         "py" to pythonRules,
         "python" to pythonRules,
+        "gyp" to pythonRules,
 
         "rs" to rustRules,
         "rust" to rustRules,
@@ -249,9 +250,13 @@ object CodeRules {
       
         "js" to javascriptRules,
         "javascript" to javascriptRules,
+        "jsx" to javascriptRules,
         
         "ts" to typescriptRules,
         "typescript" to typescriptRules,
+        "tsx" to typescriptRules,
+        "mts" to typescriptRules,
+        "cts" to typescriptRules,
 
         "patch" to diffRules,
         "diff" to diffRules


### PR DESCRIPTION
This PR adds the following alternatives:
- jsx for JavaScript
- gyp for Python
- cts, mts, and tsx for TypeScript
- patch for Diff

I didn't touch xml/http alternatives